### PR TITLE
Fix plugins usage in READMEs

### DIFF
--- a/packages/external-links/README.md
+++ b/packages/external-links/README.md
@@ -43,7 +43,7 @@ npm install --save-dev @sardine/eleventy-plugin-external-links
 ## How to use it
 
 ```javascript
-const safeLinks = require('@sardine/eleventy-plugin-external-links');
+const safeLinks = require('@sardine/eleventy-plugin-external-links').default;
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(safeLinks);
 };

--- a/packages/image-optimiser/README.md
+++ b/packages/image-optimiser/README.md
@@ -21,7 +21,7 @@ npm install --save-dev @sardine/eleventy-plugin-image-optimiser
 
 ```javascript
 // .eleventy.js
-const imageOptimiser = require('@sardine/eleventy-plugin-image-optimiser');
+const imageOptimiser = require('@sardine/eleventy-plugin-image-optimiser').default;
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(imageOptimiser);
 };

--- a/packages/tinycss/README.md
+++ b/packages/tinycss/README.md
@@ -107,7 +107,7 @@ npm install --save-dev @sardine/eleventy-plugin-tinycss
 ## How to use it
 
 ```javascript
-const tinyCSS = require('@sardine/eleventy-plugin-tinycss');
+const tinyCSS = require('@sardine/eleventy-plugin-tinycss').default;
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(tinyCSS);
 };
@@ -120,7 +120,7 @@ module.exports = function (eleventyConfig) {
 By default the plugin uses `_site` as the 11ty output directory. If you're using other directory you'll need to tell the plugin:
 
 ```javascript
-const tinyCSS = require('@sardine/eleventy-plugin-tinycss');
+const tinyCSS = require('@sardine/eleventy-plugin-tinycss').default;
 module.exports = function (eleventyConfig) {
   const tinyOptions = {
     output: 'dist',
@@ -154,7 +154,7 @@ By default the following options are used:
 You can pass your own options just like in [the official documentation](https://purgecss.com/plugins/postcss.html#options) :
 
 ```javascript
-const tinyCSS = require('@sardine/eleventy-plugin-tinycss');
+const tinyCSS = require('@sardine/eleventy-plugin-tinycss').default;
 module.exports = function (eleventyConfig) {
   const tinyOptions = {
     purgeCSS: {
@@ -172,7 +172,7 @@ module.exports = function (eleventyConfig) {
 You can pass your own options just like in [the official documentation](https://github.com/postcss/autoprefixer#options) :
 
 ```javascript
-const tinyCSS = require('@sardine/eleventy-plugin-tinycss');
+const tinyCSS = require('@sardine/eleventy-plugin-tinycss').default;
 module.exports = function (eleventyConfig) {
   const tinyOptions = {
     autoprefixer: {

--- a/packages/tinyhtml/README.md
+++ b/packages/tinyhtml/README.md
@@ -25,7 +25,7 @@ npm install --save-dev @sardine/eleventy-plugin-tinyhtml
 ## How to use it
 
 ```javascript
-const tinyHTML = require('@sardine/eleventy-plugin-tinyhtml');
+const tinyHTML = require('@sardine/eleventy-plugin-tinyhtml').default;
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(tinyHTML);
 };
@@ -34,7 +34,7 @@ module.exports = function (eleventyConfig) {
 ## Configuration
 
 ```javascript
-const tinyHTML = require('@sardine/eleventy-plugin-tinyhtml');
+const tinyHTML = require('@sardine/eleventy-plugin-tinyhtml').default;
 module.exports = function (eleventyConfig) {
   const tinyHTMLOptions = {
     html5: true,

--- a/packages/tinysvg/README.md
+++ b/packages/tinysvg/README.md
@@ -21,10 +21,12 @@ npm install --save-dev @sardine/eleventy-plugin-tinysvg
 ## How to use it
 
 ```javascript
-const tinysvg = require('@sardine/eleventy-plugin-tinysvg');
-eleventyConfig.addPlugin(tinysvg, {
-  baseUrl: 'site/_assets/svg/',
-});
+const tinysvg = require('@sardine/eleventy-plugin-tinysvg').default;
+module.exports = function (eleventyConfig) {
+  eleventyConfig.addPlugin(tinysvg, {
+    baseUrl: 'site/_assets/svg/',
+  });
+};
 ```
 
 ## License


### PR DESCRIPTION
When trying to use the plugin according to the README files, I kept getting the following error:

```
  Eleventy:EleventyErrorHandler (error stack): UserConfigError: Invalid EleventyConfig.addPlugin signature. Should be a function or a valid Eleventy plugin object.
```

After doing some investigations, the generated code by Parcel does not return a function, but an object with a `default` property which contains the function exported as a default one in plugins’ source code.

Small steps to reproduce outside of the context of the plugins:

```js
// source.js
export default (a, b) => {
  return a + b;
};

// test.js
const add = require("./dist/main");

console.log(add); // { default: [Getter] }
console.log(add.default); // [Function: $4fa36e821943b400$export$2e2bcd8739ae039]
console.log(add(2, 3)); // Throws error "TypeError: add is not a function"
```

Adding `.default` at the end of the `require` statements seems to do the trick and plugins are not preventing Eleventy from starting the server/building the project.

An alternative approach would be to change the source code to not use the `export default () => {}` syntax, but `module.exports = () => {}` - the latter would result in `const testPlugin = require("plugin-package");` to be actually a function (if you prefer the latter, I’ll happily make adjustments to this PR).

Full log for more details:

```
$ DEBUG=Eleventy* eleventy --serve
  Eleventy:cmd command: eleventy { _: [], quiet: null, version: false, watch: false, dryrun: false, help: false, serve: true, passthroughall: false, incremental: false } +0ms
  Eleventy:EventBus Setting up global EventBus. +0ms
  Eleventy:UserConfig Resetting EleventyConfig to initial values. +0ms
  Eleventy:UserConfig Adding universal filter 'slug' +5ms
  Eleventy:UserConfig Adding universal filter 'slugify' +0ms
  Eleventy:UserConfig Adding universal filter 'url' +0ms
  Eleventy:UserConfig Adding universal filter 'log' +0ms
  Eleventy:UserConfig Adding universal filter 'serverlessUrl' +0ms
  Eleventy:UserConfig Adding universal filter 'getCollectionItem' +0ms
  Eleventy:UserConfig Adding universal filter 'getPreviousCollectionItem' +0ms
  Eleventy:UserConfig Adding universal filter 'getNextCollectionItem' +0ms
  Eleventy:TemplateConfig rootConfig { templateFormats: [ 'liquid',   'ejs', 'md',       'hbs', 'mustache', 'haml', 'pug',      'njk', 'html',     '11ty.js' ], pathPrefix: '/', markdownTemplateEngine: 'liquid', htmlTemplateEngine: 'liquid', dataTemplateEngine: false, htmlOutputSuffix: '-o', jsDataFileSuffix: '.11tydata', keys: { package: 'pkg', layout: 'layout', permalink: 'permalink', permalinkRoot: 'permalinkBypassOutputDir', engineOverride: 'templateEngineOverride', computed: 'eleventyComputed' }, dir: { input: '.', includes: '_includes', data: '_data', output: '_site' }, handlebarsHelpers: {}, nunjucksFilters: {} } +0ms
  Eleventy Setting process.env.ELEVENTY_ROOT: '/Users/lukaszklis/dev/personal/project-x' +0ms
  Eleventy:TemplateConfig Merging config with /Users/lukaszklis/dev/personal/project-x/.eleventy.js +1ms
  Eleventy:UserConfig Adding anonymous plugin +622ms
  Eleventy:UserConfig Adding anonymous plugin +1ms
[11ty] Eleventy CLI Fatal Error:
[11ty] Invalid EleventyConfig.addPlugin signature. Should be a function or a valid Eleventy plugin object.

`UserConfigError` was thrown:
  Eleventy:EleventyErrorHandler (error stack): UserConfigError: Invalid EleventyConfig.addPlugin signature. Should be a function or a valid Eleventy plugin object.
  Eleventy:EleventyErrorHandler     at UserConfig._executePlugin (/Users/lukaszklis/dev/personal/project-x/node_modules/@11ty/eleventy/src/UserConfig.js:345:13)
  Eleventy:EleventyErrorHandler     at /Users/lukaszklis/dev/personal/project-x/node_modules/@11ty/eleventy/src/TemplateConfig.js:187:23
  Eleventy:EleventyErrorHandler     at Array.forEach (<anonymous>)
  Eleventy:EleventyErrorHandler     at TemplateConfig.processPlugins (/Users/lukaszklis/dev/personal/project-x/node_modules/@11ty/eleventy/src/TemplateConfig.js:185:29)
  Eleventy:EleventyErrorHandler     at TemplateConfig.mergeConfig (/Users/lukaszklis/dev/personal/project-x/node_modules/@11ty/eleventy/src/TemplateConfig.js:253:10)
  Eleventy:EleventyErrorHandler     at TemplateConfig.getConfig (/Users/lukaszklis/dev/personal/project-x/node_modules/@11ty/eleventy/src/TemplateConfig.js:117:26)
  Eleventy:EleventyErrorHandler     at new Eleventy (/Users/lukaszklis/dev/personal/lukaszklis.com/node_modules/@11ty/eleventy/src/Eleventy.js:74:39)
  Eleventy:EleventyErrorHandler     at Object.<anonymous> (/Users/lukaszklis/dev/personal/lukaszklis.com/node_modules/@11ty/eleventy/cmd.js:65:14)
  Eleventy:EleventyErrorHandler     at Module._compile (node:internal/modules/cjs/loader:1101:14)
  Eleventy:EleventyErrorHandler     at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10) +0ms
error Command failed with exit code 1.
```